### PR TITLE
fix timing window between imagestream import and start-build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,8 @@ try { // Use a try block to perform cleanup in a finally block when the build fa
       } else {
         sh "oc process -f ose3/pipeline-application-template.json -n ${project} | oc apply -f - -n ${project}"
       }
+      // sleep a bit to allow the imagestreams to be populated before we move on to building
+      sh "sleep 30"
     }
 
     stage ('Build Image') {


### PR DESCRIPTION
@jorgemoralespou @csrwng @bparees  FYI / PTAL

Some testing that @csrwng added to https://github.com/openshift/origin that leverages this repo was intermittently failing if the import of images to the s2i-java imagestream did not complete before subsequent builds which referenced that imagestream started.

An example of the failure:

```
+ oc process -f ose3/pipeline-application-template.json -n extended-test-jenkins-pipeline-14z3w-n9f3d
imagestream "s2i-java" created
service "mongodb" created
deploymentconfig "mongodb" created
imagestream "nationalparks" created
buildconfig "nationalparks-docker" created
deploymentconfig "nationalparks" created
service "nationalparks" created
route "nationalparks" created
[Pipeline] }
[Pipeline] // stage
[Pipeline] stage
[Pipeline] { (Build Image)
[Pipeline] sh
[workspace] Running shell script
+ oc start-build nationalparks-docker --from-dir=./docker --follow -n extended-test-jenkins-pipeline-14z3w-n9f3d
Uploading directory "docker" as binary input for the build ...
The ImageStreamTag "s2i-java:latest" is invalid.
from: Error resolving ImageStreamTag s2i-java:latest in namespace extended-test-jenkins-pipeline-14z3w-n9f3d: imagestreamtags "s2i-java:latest" not found
```
