### PR TITLE
Remove unused Spring cloud references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,6 @@
             <artifactId>spring-messaging</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-context</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.0.1</version>
@@ -81,19 +77,6 @@
             <version>2.3.3</version>
       </dependency>
     </dependencies>
-
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Brixton.SR4</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <finalName>${project.artifactId}</finalName>


### PR DESCRIPTION
Spring cloud Red Hat maven repos as used by OpenShift builds seems to be broken, so easiest fix here is to remove unused dependencies