### PR TITLE
error creating pipeline

### DIFF
--- a/pipeline/nationalparks-pipeline-all-new.yaml
+++ b/pipeline/nationalparks-pipeline-all-new.yaml
@@ -24,7 +24,7 @@ spec:
       type: string
     - name: TLSVERIFY
       description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
-      default: "false"
+      default: false
       type: string
     - name: OUTPUT_IMAGE_STREAM
       type: string


### PR DESCRIPTION
 oc create -f https://github.com/openshift-roadshow/nationalparks/tree/master/pipeline/nationalparks-pipeline-all-new.yaml -n user1
error: error parsing https://github.com/openshift-roadshow/nationalparks/tree/master/pipeline/nationalparks-pipeline-all-new.yaml: error converting YAML to JSON: yaml: line 27: mapping values are not allowed in this context